### PR TITLE
Fix ggmono

### DIFF
--- a/Almarai/Almarai-font-snippet.json
+++ b/Almarai/Almarai-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Almarai/Almarai-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Almarai/Almarai-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Almarai/Almarai-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Almarai/Almarai-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Almarai/Almarai-Semibold.ttf?raw=1"
     }
 }

--- a/Cabin/Cabin-font-snippet.json
+++ b/Cabin/Cabin-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Cabin/Cabin-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Cabin/Cabin-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Cabin/Cabin-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Cabin/Cabin-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Cabin/Cabin-Semibold.ttf?raw=1"
     }
 }

--- a/ComicSans/ComicSans-font-snippet.json
+++ b/ComicSans/ComicSans-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/ComicSans/ComicSans-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/ComicSans/ComicSans-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/ComicSans/ComicSans-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/ComicSans/ComicSans-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/ComicSans/ComicSans-Semibold.ttf?raw=1"
     }
 }

--- a/Evolve-Sans-EVO/Evolve-Sans-EVO-font-snippet.json
+++ b/Evolve-Sans-EVO/Evolve-Sans-EVO-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Evolve-Sans-EVO/Evolve-Sans-EVO-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Evolve-Sans-EVO/Evolve-Sans-EVO-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Evolve-Sans-EVO/Evolve-Sans-EVO-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Evolve-Sans-EVO/Evolve-Sans-EVO-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Evolve-Sans-EVO/Evolve-Sans-EVO-Semibold.ttf?raw=1"
     }
 }

--- a/Fira-Code/Fira-Code-font-snippet.json
+++ b/Fira-Code/Fira-Code-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Fira-Code/Fira-Code-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Fira-Code/Fira-Code-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Fira-Code/Fira-Code-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Fira-Code/Fira-Code-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Fira-Code/Fira-Code-Semibold.ttf?raw=1"
     }
 }

--- a/Gantari/Gantari-font-snippet.json
+++ b/Gantari/Gantari-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Gantari/Gantari-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Gantari/Gantari-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Gantari/Gantari-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Gantari/Gantari-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Gantari/Gantari-Semibold.ttf?raw=1"
     }
 }

--- a/Golos-Text/Golos-Text-font-snippet.json
+++ b/Golos-Text/Golos-Text-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Golos-Text/Golos-Text-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Golos-Text/Golos-Text-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Golos-Text/Golos-Text-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Golos-Text/Golos-Text-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Golos-Text/Golos-Text-Semibold.ttf?raw=1"
     }
 }

--- a/GoogleSans/GoogleSans-font-snippet.json
+++ b/GoogleSans/GoogleSans-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/GoogleSans/GoogleSans-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/GoogleSans/GoogleSans-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/GoogleSans/GoogleSans-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/GoogleSans/GoogleSans-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/GoogleSans/GoogleSans-Semibold.ttf?raw=1"
     }
 }

--- a/IBM_Plex_Mono/IBM_Theme.json
+++ b/IBM_Plex_Mono/IBM_Theme.json
@@ -25,6 +25,6 @@
       	    "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-Normal.ttf?raw=1",
       	    "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-NormalItalic.ttf?raw=1",
       	    "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1",
-      	    "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1"
+			"ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1"
 	}
 }

--- a/IBM_Plex_Mono/ibm_flex_mono.json
+++ b/IBM_Plex_Mono/ibm_flex_mono.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/IBM_Plex_Mono/IBMPlexMono-SemiBold.ttf?raw=1"
     }
 }

--- a/InstrumentSans/InstrumentSans-font-snippet.json
+++ b/InstrumentSans/InstrumentSans-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/InstrumentSans/InstrumentSans-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/InstrumentSans/InstrumentSans-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/InstrumentSans/InstrumentSans-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/InstrumentSans/InstrumentSans-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/InstrumentSans/InstrumentSans-Semibold.ttf?raw=1"
     }
 }

--- a/Inter/Inter-font-snippet.json
+++ b/Inter/Inter-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Inter/Inter-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Inter/Inter-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Inter/Inter-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Inter/Inter-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Inter/Inter-Semibold.ttf?raw=1"
     }
 }

--- a/JetBrainsMono/JetBrainsMono-font-snippet.json
+++ b/JetBrainsMono/JetBrainsMono-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/JetBrainsMono/JetBrainsMono-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/JetBrainsMono/JetBrainsMono-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/JetBrainsMono/JetBrainsMono-SemiBold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/JetBrainsMono/JetBrainsMono-SemiBold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/JetBrainsMono/JetBrainsMono-SemiBold.ttf?raw=1"
     }
 }

--- a/Linotte/Linotte-font-snippet.json
+++ b/Linotte/Linotte-font-snippet.json
@@ -20,6 +20,6 @@
             "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Linotte/Linotte-Normal.ttf?raw=1",
             "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Linotte/Linotte-NormalItalic.ttf?raw=1",
             "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Linotte/Linotte-Semibold.ttf?raw=1",
-            "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Linotte/Linotte-Semibold.ttf?raw=1"
+            "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Linotte/Linotte-Semibold.ttf?raw=1"
     }
 }

--- a/Meloso/Meloso-font-snippet.json
+++ b/Meloso/Meloso-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Meloso/Meloso-Normal.otf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Meloso/Meloso-NormalItalic.otf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Meloso/Meloso-Semibold.otf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Meloso/Meloso-SemiboldItalic.otf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Meloso/Meloso-SemiboldItalic.otf?raw=1"
   }
 }

--- a/Mikhak/Mikhak-font-snippet.json
+++ b/Mikhak/Mikhak-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Mikhak/Mikhak-Normal.ttf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Mikhak/Mikhak-NormalItalic.ttf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Mikhak/Mikhak-SemiBold.ttf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Mikhak/Mikhak-SemiBold.ttf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Mikhak/Mikhak-SemiBold.ttf?raw=1"
   }
 }

--- a/OPPOSans4.0/OPPOSans-font-snippet.json
+++ b/OPPOSans4.0/OPPOSans-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OPPOSans4.0/OPPOSans4.0-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/OPPOSans4.0/OPPOSans4.0-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OPPOSans4.0/OPPOSans4.0-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OPPOSans4.0/OPPOSans4.0-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OPPOSans4.0/OPPOSans4.0-Semibold.ttf?raw=1"
     }
 }

--- a/OnePlusSans/OnePlusSans-font-snippet.json
+++ b/OnePlusSans/OnePlusSans-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSans/OnePlusSans-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSans/OnePlusSans-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSans/OnePlusSans-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSans/OnePlusSans-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSans/OnePlusSans-Semibold.ttf?raw=1"
     }
 }

--- a/OnePlusSlate/OnePlusSlate-font-snippet.json
+++ b/OnePlusSlate/OnePlusSlate-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSlate-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSlate/OnePlusSlate-Normal.ttf?raw=1",
         "NotoSlate-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSlate/OnePlusSlate-NormalItalic.ttf?raw=1",
         "NotoSlate-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSlate/OnePlusSlate-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSlate/OnePlusSlate-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OnePlusSlate/OnePlusSlate-Semibold.ttf?raw=1"
     }
 }

--- a/OpenDyslexic/OpenDyslexic-font-snippet.json
+++ b/OpenDyslexic/OpenDyslexic-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OpenDyslexic/OpenDyslexic-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/OpenDyslexic/OpenDyslexic-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OpenDyslexic/OpenDyslexic-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/OpenDyslexic/OpenDyslexic-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/OpenDyslexic/OpenDyslexic-Semibold.ttf?raw=1"
     }
 }

--- a/Playfair/Playfair-font-snippet.json
+++ b/Playfair/Playfair-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Playfair/Playfair-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Playfair/Playfair-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Playfair/Playfair-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Playfair/Playfair-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Playfair/Playfair-Semibold.ttf?raw=1"
     }
 }

--- a/Quicksand/Quicksand-font-snippet.json
+++ b/Quicksand/Quicksand-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Quicksand/Quicksand-Normal.ttf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Quicksand/Quicksand-NormalItalic.ttf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Quicksand/Quicksand-Semibold.ttf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Quicksand/Quicksand-Semibold.ttf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Quicksand/Quicksand-Semibold.ttf?raw=1"
   }
 }

--- a/SF-Pro-Display/SF-Pro-Display-font-snippet.json
+++ b/SF-Pro-Display/SF-Pro-Display-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/SF-Pro-Display/SF-Pro-Display-Normal.otf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/SF-Pro-Display/SF-Pro-Display-NormalItalic.otf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/SF-Pro-Display/SF-Pro-Display-Semibold.otf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/SF-Pro-Display/SF-Pro-Display-Semibold.otf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/SF-Pro-Display/SF-Pro-Display-Semibold.otf?raw=1"
   }
 }

--- a/Source-Code-Pro/Source-Code-Pro-font-snippet.json
+++ b/Source-Code-Pro/Source-Code-Pro-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Source-Code-Pro/Source-Code-Pro-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Source-Code-Pro/Source-Code-Pro-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Source-Code-Pro/Source-Code-Pro-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Source-Code-Pro/Source-Code-Pro-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Source-Code-Pro/Source-Code-Pro-Semibold.ttf?raw=1"
     }
 }

--- a/Space-Mono/Space-Mono-font-snippet.json
+++ b/Space-Mono/Space-Mono-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Space-Mono/Space-Mono-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Space-Mono/Space-Mono-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Space-Mono/Space-Mono-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Space-Mono/Space-Mono-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Space-Mono/Space-Mono-Semibold.ttf?raw=1"
     }
 }

--- a/Trakya/Trakya-Sans-font-snippet.json
+++ b/Trakya/Trakya-Sans-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Trakya/Trakya-Sans-Normal.ttf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Trakya/Trakya-Sans-Normaltalic.ttf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Trakya/Trakya-Sans-Semibold.ttf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Trakya/Trakya-Sans-Semibold.ttf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Trakya/Trakya-Sans-Semibold.ttf?raw=1"
   }
 }

--- a/UbuntuSansMono/UbuntuSansMono-font-snippet.json
+++ b/UbuntuSansMono/UbuntuSansMono-font-snippet.json
@@ -20,6 +20,6 @@
         "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/UbuntuSansMono/UbuntuSansMono-Normal.ttf?raw=1",
         "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/UbuntuSansMono/UbuntuSansMono-NormalItalic.ttf?raw=1",
         "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/UbuntuSansMono/UbuntuSansMono-Semibold.ttf?raw=1",
-        "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/UbuntuSansMono/UbuntuSansMono-Semibold.ttf?raw=1"
+        "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/UbuntuSansMono/UbuntuSansMono-Semibold.ttf?raw=1"
     }
 }

--- a/Whitney/Whitney-font-snippet.json
+++ b/Whitney/Whitney-font-snippet.json
@@ -20,6 +20,6 @@
       "NotoSans-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Whitney/Whitney-Normal.ttf?raw=1",
       "NotoSans-NormalItalic": "https://github.com/Rairof/Theme-Fonts/raw/main/Whitney/Whitney-NormalItalic.ttf?raw=1",
       "NotoSans-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Whitney/Whitney-Semibold.ttf?raw=1",
-      "SourceCodePro-Semibold": "https://github.com/Rairof/Theme-Fonts/raw/main/Whitney/Whitney-Semibold.ttf?raw=1"
+      "ggmono-Normal": "https://github.com/Rairof/Theme-Fonts/raw/main/Whitney/Whitney-Semibold.ttf?raw=1"
   }
 }


### PR DESCRIPTION
Discord now uses a font called `ggmono` for code blocks, instead of `Source Code Pro`. This PR fixes the problem caused by that change.